### PR TITLE
Add backend and frontend placeholders

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,16 @@
+# Backend
+
+This folder contains the server-side code for the Synergy Tutor pilot. The current setup uses a minimal [FastAPI](https://fastapi.tiangolo.com/) app as a starting point.
+
+## Running Locally
+
+1. Install dependencies:
+   ```bash
+   pip install fastapi uvicorn
+   ```
+2. Start the development server:
+   ```bash
+   uvicorn main:app --reload
+   ```
+
+This will serve the API at `http://localhost:8000/`.

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,7 @@
+from fastapi import FastAPI
+
+app = FastAPI()
+
+@app.get("/")
+def read_root():
+    return {"message": "Synergy Tutor backend placeholder"}

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,13 @@
+# Frontend
+
+This directory is reserved for the user-facing application. The pilot will eventually use a React/Next.js interface. For now, this folder contains documentation and starter files.
+
+## Getting Started
+
+1. Ensure you have [Node.js](https://nodejs.org/) installed.
+2. Create a new Next.js project when ready:
+   ```bash
+   npx create-next-app@latest
+   ```
+
+Additional instructions will be added as the project evolves.


### PR DESCRIPTION
## Summary
- set up `backend` folder with FastAPI README and stub app
- create `frontend` folder with initial React/Next.js instructions

## Testing
- `git status --short`