### PR TITLE
Add contribution and docs references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,12 @@
+# Contributing
+
+We welcome contributions! Please open an issue to discuss major changes before submitting a pull request.
+
+When contributing:
+
+1. Fork the repository and create your branch from `main`.
+2. Follow the style and conventions used throughout the project.
+3. Add tests or documentation when applicable.
+4. Ensure `README.md` and relevant docs are updated.
+
+For any questions, feel free to open a discussion or reach out via issues.

--- a/README.md
+++ b/README.md
@@ -88,3 +88,20 @@ This document outlines the blueprint for a 30-student "Synergy Tutor" pilot prog
 7.  **Conduct Teacher Training**:
     *   Schedule a 60-minute Zoom session.
     *   Cover dashboard usage and best practices for prompt hygiene.
+
+## Setup
+
+For installation and configuration, see [docs/SETUP.md](docs/SETUP.md).
+
+## Contributing
+
+Guidelines for contributing can be found in [CONTRIBUTING.md](CONTRIBUTING.md).
+
+## Additional Documentation
+
+* API reference: [docs/API.md](docs/API.md)
+* Database schema: [docs/DATABASE.md](docs/DATABASE.md)
+
+## License
+
+This project is licensed under the [Apache 2.0](LICENSE) license.


### PR DESCRIPTION
## Summary
- add a CONTRIBUTING guide
- reference setup docs, contribution guide, API and DB docs in README
- link to the license

## Testing
- `pytest -q` *(fails: command not found)*